### PR TITLE
Including model atmospheres in MPIA corrections

### DIFF
--- a/NLTE_correction_MPIA.ipynb
+++ b/NLTE_correction_MPIA.ipynb
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "aefaa849",
    "metadata": {},
    "outputs": [],
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "f5308323",
    "metadata": {},
    "outputs": [],
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 3,
    "id": "fd0b893e",
    "metadata": {},
    "outputs": [],
@@ -80,12 +80,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 4,
    "id": "e0d7585c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "def nlte_cor(elem, lines, t, g, feh, vt):\n",
+    "def nlte_cor(elem, lines, t, g, feh, vt, model_atmos='mafags-os'):\n",
     "    \"\"\"\n",
     "    DESCRIPTION --------------------------------------------------------\n",
     "        Given input parameters, return the NLTE correction performed by MPIA\n",
@@ -99,6 +99,9 @@
     "        g (float) - the surface gravity of your star\n",
     "        feh (float) - the metallicity [Fe/H] of your star\n",
     "        vt (float) - the micro-turbulent velocity of your star\n",
+    "        model_atmos (string) - atmosphere model choice {options: mafags-os, marcs, rsg}\n",
+    "            check mpia website for details on the stellar parameter range for each\n",
+    "            grid\n",
     "        \n",
     "    RETURNS -------------------------------------------------------------\n",
     "        np.array() - a 2D numpy array with 3 elements per row, such that each row\n",
@@ -119,6 +122,9 @@
     "    #  a separate webpage\n",
     "    if elem in [8.01, 25.01, 27.01]:\n",
     "        weblink = 'https://nlte.mpia.de/gui-siuAC_secEnew.php'\n",
+    "        if model_atmos != 'mafags-os':\n",
+    "            print(f'{model_atmos} is not available for {elem}, using mafags-os instead')\n",
+    "        model_atmos = 'mafags-os'\n",
     "    else:\n",
     "        weblink = \"https://nlte.mpia.de/gui-siuAC_secE.php\"\n",
     "    \n",
@@ -126,6 +132,31 @@
     "    browser.open(weblink)\n",
     "    \n",
     "    form = browser.select_form()\n",
+    "    \n",
+    "    if model_atmos == 'marcs':\n",
+    "        for name, param, upper_lim, lower_lim in zip(['Teff', 'Logg', '[Fe/H]'],\n",
+    "                                                     [t, g, feh], \n",
+    "                                                     [7750, 3.5, 1.0], \n",
+    "                                                     [2500, -0.5, -5.0]):\n",
+    "            if (param < lower_lim) or (param > upper_lim):\n",
+    "                print(f'{name} = {param} is not within the {model_atmos} grid [{lower_lim}, {upper_lim}]')\n",
+    "                print(f'Using mafags-os atmosphere grid instead')\n",
+    "                model_atmos = 'mafags-os'\n",
+    "                break\n",
+    "    elif model_atmos == 'marcs':\n",
+    "        for name, param, upper_lim, lower_lim in zip(['Teff', 'Logg', '[Fe/H]'],\n",
+    "                                                     [t, g, feh], \n",
+    "                                                     [4400, 1.0, 1.0], \n",
+    "                                                     [3400, -0.99, -1.5]):\n",
+    "            if (param < lower_lim) or (param > upper_lim):\n",
+    "                print(f'{name} = {param} is not within the {model_atmos} grid [{lower_lim}, {upper_lim}]')\n",
+    "                print(f'Using mafags-os atmosphere grid instead')\n",
+    "                model_atmos = 'mafags-os'\n",
+    "                break\n",
+    "\n",
+    "\n",
+    "                \n",
+    "    form[\"model\"] = model_atmos\n",
     "    \n",
     "    param_txt = \"{} {} {} {} {}\".format('my_star', t, g, feh, vt)\n",
     "    form.set_textarea({\"user_input\":param_txt})\n",
@@ -137,7 +168,7 @@
     "        line_txt += append\n",
     "        \n",
     "    form.set_textarea({\"lines_input\":line_txt})\n",
-    "    \n",
+    "        \n",
     "    browser.submit_selected()\n",
     "        \n",
     "    result_txt = browser.page.get_text().split('lines(A)')[-1].split('Download')[0].split('my_star')\n",
@@ -174,7 +205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 5,
    "id": "3c0dce8d",
    "metadata": {},
    "outputs": [],
@@ -184,7 +215,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 6,
    "id": "8dda7818",
    "metadata": {},
    "outputs": [
@@ -192,19 +223,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Line not in linelist at: 26.01 5379.574\n",
-      "Line not in linelist at: 26.01 8179.03\n"
+      "Line not in linelist (or too weak) at: 26.01 5379.574\n",
+      "Line not in linelist (or too weak) at: 26.01 8179.03\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "array([['26.01', '5379.574', '999'],\n",
+       "array([['26.01', '5379.574', '999.0'],\n",
        "       ['26.01', '3125.68', '0.139'],\n",
-       "       ['26.01', '8179.03', '999']], dtype='<U32')"
+       "       ['26.01', '8179.03', '999.0']], dtype='<U32')"
       ]
      },
-     "execution_count": 56,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -262,7 +293,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 7,
    "id": "2e5c8f9a",
    "metadata": {},
    "outputs": [],
@@ -282,7 +313,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 8,
    "id": "f2c4be86",
    "metadata": {},
    "outputs": [
@@ -325,7 +356,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 9,
    "id": "e88191ee",
    "metadata": {},
    "outputs": [
@@ -434,7 +465,7 @@
        "9  26.02   3565.38  999.0"
       ]
      },
-     "execution_count": 90,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -456,7 +487,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -470,7 +501,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I added in an optional keyword command to specify the model atmosphere choice for the MPIA NLTE corrections, along with some checks to see if the request is on the non-default grids and resort to the default grid if not.